### PR TITLE
[수정] Spot모델의 firstimage 필드를 textfield로 수정

### DIFF
--- a/routes/models.py
+++ b/routes/models.py
@@ -26,7 +26,7 @@ class Spot(models.Model):
     addr2 = models.CharField("상세주소", max_length=200, blank=True, null=True)
     mapx = models.FloatField("x좌표")
     mapy = models.FloatField("y좌표")
-    firstimage = models.ImageField("이미지", upload_to="Spot/%Y/%m/", blank=True, null=True)
+    firstimage = models.TextField("이미지", blank=True, null=True)
     tel = models.CharField("전화번호", max_length=20, blank=True, null=True)
     
     def __str__(self):


### PR DESCRIPTION
Spot모델의 firstimage 필드를 imagefield로 잘못 지정하고 있었습니다.

json파일에서 이미지 url을 가져와 저장은 되었으나 불러오질 못한다는 소식을 듣고 

나눴던 대화내용대로 TextField로 수정완료했습니다.