### PR TITLE
여행루트 routespot 모델 추가, 시리얼라이저 수정, 필드 수정

### DIFF
--- a/routes/models.py
+++ b/routes/models.py
@@ -14,11 +14,18 @@ class Route(models.Model):
     cost = models.IntegerField("경비")
     duration = models.CharField("기간", max_length=50)
     spots = models.ManyToManyField(
-        Spot, verbose_name="루트스팟", blank=True, related_name='routes')
+        Spot, verbose_name="루트스팟", blank=True, related_name='routes', through='RouteSpot')
 
     def __str__(self):
         return self.title
 
+
+class RouteSpot(models.Model):
+    route = models.ForeignKey(Route, on_delete=models.CASCADE, related_name="route_spots")
+    spot = models.ForeignKey(Spot, on_delete=models.CASCADE)
+    order = models.IntegerField("순서")
+    day = models.IntegerField("일차")
+    
 
 class RouteArea(models.Model):
     route = models.ForeignKey(Route, verbose_name="경로",

--- a/routes/models.py
+++ b/routes/models.py
@@ -11,8 +11,8 @@ class Route(models.Model):
     created_at = models.DateTimeField("작성시각", auto_now_add=True)
     updated_at = models.DateTimeField("수정시각", auto_now=True)
     image = models.ImageField("이미지", upload_to="Routes/%Y/%m/", blank=True)
-    cost = models.IntegerField("경비")
-    duration = models.CharField("기간", max_length=50)
+    cost = models.PositiveIntegerField("경비")
+    duration = models.PositiveIntegerField("기간")
     spots = models.ManyToManyField(
         Spot, verbose_name="루트스팟", blank=True, related_name='routes', through='RouteSpot')
 
@@ -23,8 +23,8 @@ class Route(models.Model):
 class RouteSpot(models.Model):
     route = models.ForeignKey(Route, on_delete=models.CASCADE, related_name="route_spots")
     spot = models.ForeignKey(Spot, on_delete=models.CASCADE)
-    order = models.IntegerField("순서")
-    day = models.IntegerField("일차")
+    order = models.PositiveIntegerField("순서")
+    day = models.PositiveIntegerField("일차")
     
 
 class RouteArea(models.Model):
@@ -32,7 +32,7 @@ class RouteArea(models.Model):
                               on_delete=models.CASCADE, related_name="areas")
     area = models.ForeignKey(Area, verbose_name="시도", on_delete=models.CASCADE,
                              related_name="routes", blank=True, null=True)
-    sigungu = models.IntegerField("시군구", blank=True, null=True)
+    sigungu = models.PositiveIntegerField("시군구", blank=True, null=True)
 
     def __str__(self):
         return f"Route: {self.route.title}, Area: {self.area.name}, Sigungu: {self.sigungu}"
@@ -43,7 +43,7 @@ class RouteRate(models.Model):
                               on_delete=models.CASCADE, related_name="rates")
     user = models.ForeignKey(User, verbose_name="작성자",
                              on_delete=models.CASCADE, related_name="rates")
-    rate = models.IntegerField("평가", default=0)
+    rate = models.PositiveIntegerField("평가", default=0)
 
 
 class Comment(models.Model):

--- a/routes/serializers.py
+++ b/routes/serializers.py
@@ -1,9 +1,9 @@
 from rest_framework import serializers
 from django.db.models import Avg
 
-from .models import Route, Comment, RouteArea
+from .models import Route, Comment, RouteArea, RouteSpot
 
-from spots.models import Area
+from spots.models import Area, Spot
 from spots.serializers import SpotSerializer
 
 # 여행경로 지역
@@ -11,6 +11,13 @@ class RouteAreaSerializer(serializers.ModelSerializer):
     class Meta:
         model = RouteArea
         fields = ('area', 'sigungu')
+        
+class RouteSpotSerializer(serializers.ModelSerializer):
+    spot = SpotSerializer()
+    
+    class Meta:
+        model = RouteSpot
+        fields = ['spot', 'order', 'day']
 
 
 # 여행경로 전체 조회
@@ -54,6 +61,7 @@ class CommentSerializer(serializers.ModelSerializer):
 # 여행경로 작성, 수정
 class RouteCreateSerializer(serializers.ModelSerializer):
     areas = serializers.JSONField()
+    spots = serializers.JSONField()
 
     class Meta:
         model = Route
@@ -65,19 +73,23 @@ class RouteCreateSerializer(serializers.ModelSerializer):
     def to_representation(self, instance):
         # instance의 모든 필드를 기본형식으로 변환 -> 결과를 data라는 딕셔너리로 저장
         data = super().to_representation(instance)
+        # Route에 연결된 모든 RouteSpot 객체를 찾음
+        route_spots = RouteSpot.objects.filter(route=instance)
         
         # data에 areas의 값을 바꿔줍니다.
         # RouteAreaSerializer의 instance는 RouteArea인데 areas로 엮인 모든 객체를 직렬화
         # data['areas']의 값은 RouteAreaSerializer로 직렬화된 RouteArea 객체의 데이터
         data['areas'] = RouteAreaSerializer(instance.areas.all(), many=True).data
-        
+        # spot 정보를 data의 spots키에 할당
+        data['spots'] = RouteSpotSerializer(route_spots, many=True).data
+        # data는 딕셔너리, data는 areas와 spots에 해당 정보들을 포함하고 있음
         return data
 
     def create(self, validated_data):
         # 루트지역과 루트스팟 데이터 가져오기
         # 얘네 둘은 다대다 관계로 되어 있어서 특별 취급이 필요함
         route_area_data = validated_data.pop('areas')
-        spots_data = validated_data.pop('spots')
+        route_spots_data = validated_data.pop('spots')
 
         # areas데이터의 area id를 이용해 Area객체를 데이터베이스에서 가져옴
         area = Area.objects.get(pk=route_area_data['area'])
@@ -88,14 +100,18 @@ class RouteCreateSerializer(serializers.ModelSerializer):
         route = Route.objects.create(**validated_data)
         routearea = RouteArea.objects.create(route=route, **route_area_data)
 
-        # 리스트 형태로 전달하면 리스트 자체를 하나의 인자로 처리
-        # 리스트의 요소들을 개별 인자로 전달하기 위해 *을 사용
-        route.spots.add(*spots_data)
+        # route_spots_data를 돌면서 각 spot마다의 정보를 가져옴
+        for spot_data in route_spots_data:
+            spot = Spot.objects.get(pk=spot_data['spot'])  # spots의 spot id를 이용해 Spot객체를 데이터베이스에서 가져옴
+            spot_data['spot'] = spot
+            RouteSpot.objects.create(route=route, **spot_data)
+        
         return route
 
     def update(self, instance, validated_data):
+        # 루트지역과 루트스팟 데이터 가져오기
         route_area_data = validated_data.pop('areas', None)
-        spots_data = validated_data.pop('spots', None)
+        route_spots_data = validated_data.pop('spots', None)
 
         # 새로운 정보를 기존 정보에 덮어 씌우기
         instance.title = validated_data.get('title', instance.title)
@@ -104,21 +120,26 @@ class RouteCreateSerializer(serializers.ModelSerializer):
         instance.duration = validated_data.get('duration', instance.duration)
         instance.cost = validated_data.get('cost', instance.cost)
 
-         # set()메서드는 다대다관계에서 관련된 객체들을 대체함
-        instance.spots.set(spots_data)
-
         # 기존 정보 삭제
-        instance.areas.all().delete()
-        
-        area_id = route_area_data.pop('area', None)
-        area = Area.objects.get(pk=area_id)  # Area 인스턴스를 불러옵니다.
-        
-        route_area_data['area'] = area  # Area 인스턴스를 할당합니다.
-        RouteArea.objects.create(route=instance, **route_area_data)
+        RouteArea.objects.filter(route=instance).delete()
+        RouteSpot.objects.filter(route=instance).delete()
+
+        # 새로운 areas 데이터 추가
+        if route_area_data is not None:
+            area = Area.objects.get(pk=route_area_data['area'])
+            route_area_data['area'] = area
+            RouteArea.objects.create(route=instance, **route_area_data)
+
+        # 새로운 spots 데이터 추가
+        if route_spots_data is not None:
+            for spot_data in route_spots_data:
+                spot = Spot.objects.get(pk=spot_data['spot'])
+                spot_data['spot'] = spot
+                RouteSpot.objects.create(route=instance, **spot_data)
 
         instance.save()
         return instance
-
+    
 
 # 여행경로 상세보기
 class RouteDetailSerializer(serializers.ModelSerializer):
@@ -126,7 +147,7 @@ class RouteDetailSerializer(serializers.ModelSerializer):
     comments = CommentSerializer(many=True)
     comment_count = serializers.SerializerMethodField()
     rate = serializers.SerializerMethodField()
-    spots = SpotSerializer(many=True)
+    spots = RouteSpotSerializer(source='route_spots', many=True)    # source를 붙히지 않으면 Spot의 객체를 찾으러 가버림
     areas = RouteAreaSerializer(many=True)
 
     def get_user(self, obj):
@@ -142,6 +163,7 @@ class RouteDetailSerializer(serializers.ModelSerializer):
     class Meta:
         model = Route
         fields = "__all__"
+
 
 
 # 댓글 작성, 수정

--- a/routes/serializers.py
+++ b/routes/serializers.py
@@ -11,7 +11,8 @@ class RouteAreaSerializer(serializers.ModelSerializer):
     class Meta:
         model = RouteArea
         fields = ('area', 'sigungu')
-        
+
+# 여행경로 목적지
 class RouteSpotSerializer(serializers.ModelSerializer):
     spot = SpotSerializer()
     
@@ -19,6 +20,12 @@ class RouteSpotSerializer(serializers.ModelSerializer):
         model = RouteSpot
         fields = ['spot', 'order', 'day']
 
+# 여행경로 목적지 생성
+class SpotCreateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Spot
+        fields = ['id', 'type', 'title', 'mapx', 'mapy']
+        
 
 # 여행경로 전체 조회
 class RouteSerializer(serializers.ModelSerializer):

--- a/routes/tests.py
+++ b/routes/tests.py
@@ -1,1 +1,148 @@
-from django.test import TestCase
+import json
+from rest_framework.test import APITestCase, APIClient
+
+# 이미지
+from PIL import Image
+import tempfile
+from django.test.client import MULTIPART_CONTENT, encode_multipart, BOUNDARY
+
+from routes.models import Route, Comment, RouteRate, RouteArea
+from spots.models import Area, Sigungu, Spot
+from users.models import User
+from routes.views import RouteView, SpotCreateView, RouteDetailView, CommentView, CommentDetailView, RateView
+
+
+def get_temporary_image():
+    image = Image.new('RGB', (100, 100))
+    temp_file = tempfile.NamedTemporaryFile(suffix='.jpg')
+    image.save(temp_file, 'JPEG')
+    temp_file.seek(0)
+    return temp_file
+
+class RouteViewTest(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email='user@test.com',
+            nickname='test',
+            password='0000'
+        )
+        
+        # Route안에 있는 애들이 아니라서 별도로 객체를 생성 시켜줌
+        self.area = Area.objects.create(name='서울')
+        self.spot1 = Spot.objects.create(title='남산타워', area=self.area, type=12, mapx=1.0, mapy=1.0)
+        self.spot2 = Spot.objects.create(title='롯데타워', area=self.area, type=39, mapx=2.0, mapy=2.0)
+
+        
+        # CharField나 TextField는 null=True 옵션이 없어도 명시적으로 ""가 들어감
+        # 반면 IntegerField의 경우 null=True 옵션이 없으면 NOT NULL조건이 적용됨
+        self.route = Route.objects.create(user=self.user,
+                                          title='route_test',
+                                          duration=1,
+                                          cost=1000,
+                                          content="content"
+                                          )
+        # RouteArea 객체 생성
+        self.routearea = RouteArea.objects.create(route=self.route, area=self.area, sigungu=1)
+        # route의 areas 항목에 추가
+        self.route.areas.set([self.routearea])
+
+        # 루트에 목적지 추가
+        self.route.spots.set([self.spot1, self.spot2])
+        
+        self.client = APIClient()
+        
+        ## 로그인
+        self.client.force_authenticate(user=self.user)
+
+    def test_route_view_get(self):
+        response = self.client.get(f'/routes/{self.route.id}/')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['title'], 'route_test')
+        self.assertEqual(len(response.data['spots']), 2)
+
+    # 여행루트 게시글 작성 테스트
+    def test_route_view_post(self):
+        route_data = {
+            'user': self.user.id,
+            'title': 'route_test',
+            'duration': 1,
+            'cost': 1000,
+            'areas': {
+                'area': self.area.id,
+                'sigungu': 1
+            },
+            'spots': [self.spot1.id, self.spot2.id],
+            'content': "content"
+        }
+        # 게시글 데이터를 가지고 post 요청
+        response = self.client.post('/routes/', data=route_data, format='json')
+
+        self.assertEqual(response.status_code, 201) # 서버 응답확인
+        self.assertEqual(response.data[1]['title'], 'route_test')   # 데이터 일치 여부
+        self.assertEqual(len(response.data[1]['spots']), 2) # spots의 갯수가 맞는지
+        self.assertEqual(len(response.data[1]['areas']), 1) # areas의 갯수가 맞는지
+        
+    # 여행루트 게시글 작성 테스트(이미지가 있을 때)
+    def test_route_view_post_with_image(self):
+        # 임시 이미지 생성
+        image_file = get_temporary_image()
+        route_data = {
+            'user': self.user.id,
+            'title': 'route_test',
+            'duration': 1,
+            'cost': 1000,
+            'areas': json.dumps({   # 파이썬 객체를 JSon으로 변환
+            'area': self.area.id,
+            'sigungu': 1
+            }),
+            'spots': [self.spot1.id,  self.spot2.id],
+            'content': "content",
+            'image': image_file
+        }
+        # encode_multipart: 파일과 일반 post데이터를 포함하는 인코딩 데이터를 생성
+        response = self.client.post('/routes/', encode_multipart(data=route_data, boundary=BOUNDARY), content_type=MULTIPART_CONTENT)
+        print(response.data)
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.data[1]['title'], 'route_test')
+        self.assertEqual(len(response.data[1]['spots']), 2)
+        self.assertEqual(len(response.data[1]['areas']), 1)
+
+class SpotCreateViewTest(APITestCase):
+    def setUp(self):
+
+        pass
+
+    def test_spot_create_view_post(self):
+        
+        pass
+
+
+class RouteDetailViewTest(APITestCase):
+    def setUp(self):
+
+        pass
+
+    def test_route_detail_view_get(self):
+        
+        pass
+
+    def test_route_detail_view_put(self):
+        
+        pass
+
+    def test_route_detail_view_delete(self):
+        
+        pass
+
+
+class CommentViewTest(APITestCase):
+    pass
+
+
+class CommentDetailViewTest(APITestCase):
+    pass
+
+
+class RateViewTest(APITestCase):
+    pass

--- a/routes/views.py
+++ b/routes/views.py
@@ -9,9 +9,9 @@ from routes.serializers import (
     RouteCreateSerializer,
     RouteDetailSerializer,
     CommentSerializer,
-    CommentCreateSerializer
+    CommentCreateSerializer,
+    SpotCreateSerializer
 )
-from spots.serializers import SpotSerializer
 
 
 class RouteView(ListAPIView):
@@ -49,7 +49,7 @@ class SpotCreateView(APIView):
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request):
-        serializer = SpotSerializer(data=request.data)
+        serializer = SpotCreateSerializer(data=request.data)
 
         # 유저가 기입한 정보가 유효하지 않을 때
         if not serializer.is_valid():


### PR DESCRIPTION
# 모델이 변경되어 루트관련 기존데이터 제거 및 마이그레이션이 필요합니다.

## 여행루트 모델, 시리얼라이저 수정
- 기존 Route모델에 있던 spots 필드에 순서를 담는 order와 일차를 담는 day 필드를 추가하기위해 RouteSpot모델을 만들었습니다.
- RouteSpot모델은 Route모델에 있는 spots필드를 확장하기위해 만든 모델로 through를 통해 spots필드에 연결했습니다.
- 모델 변경에 따라 시리얼라이저를 수정했습니다.

## 목적지 생성 시리얼라이저 수정
- 기존에 목적지생성 시리얼라이저는 spot폴더에 SpotSerializer를 사용하고 있었지만, 사용자가 목적지를 생성할 때 모든 필드를 사용하지 않기에 보안 상 새로운 시리얼라이저를 만들어 사용하기로 했습니다.
- Route폴더에 RouteSpotSerializer를 추가해 필요한 필드만 가져와 사용하게 수정했습니다.

## 숫자형 필드 수정
- 취약점이였던 JS를 이용한 함수 변경 공격을 방어하기 위해 양의 정수를 받는 필드들에게 모두 PositiveIntegerField를 적용했습니다.